### PR TITLE
[Documentation]: Cleanup XML Documentation For PackedVector Namespace Members

### DIFF
--- a/MonoGame.Framework/Graphics/PackedVector/Alpha8.cs
+++ b/MonoGame.Framework/Graphics/PackedVector/Alpha8.cs
@@ -14,8 +14,11 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
         private byte packedValue;
 
         /// <summary>
-        /// Gets and sets the packed value.
+        /// Gets or Sets the packed representation of this <see cref="Alpha8"/>.
         /// </summary>
+        /// <value>
+        /// The packed representation of this <see cref="Alpha8"/>
+        /// </value>
         public byte PackedValue
         {
             get
@@ -29,18 +32,20 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
         }
 
         /// <summary>
-        /// Creates a new instance of Alpha8.
+        /// Creates a new <see cref="Alpha8"/> initialized with the specified value.
         /// </summary>
-        /// <param name="alpha">The alpha component</param>
+        /// <param name="alpha">The initial value of the <see cref="Alpha8"/></param>
         public Alpha8(float alpha)
         {
             packedValue = Pack(alpha);
         }
 
         /// <summary>
-        /// Gets the packed vector in float format.
+        /// Expands this <see cref="Alpha8"/> to a <see cref="Single"/>
         /// </summary>
-        /// <returns>The packed vector in Vector3 format</returns>
+        /// <returns>
+        /// The expanded <see cref="Alpha8"/> as a <see cref="Single"/>.
+        /// </returns>
         public float ToAlpha()
         {
             return (float) (packedValue / 255.0f);
@@ -56,9 +61,11 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
         }
 
         /// <summary>
-        /// Gets the packed vector in Vector4 format.
+        /// Expands this <see cref="Alpha8"/> to a <see cref="Vector4"/>
         /// </summary>
-        /// <returns>The packed vector in Vector4 format</returns>
+        /// <returns>
+        /// The expanded <see cref="Alpha8"/> as a <see cref="Vector4"/>.
+        /// </returns>
         public Vector4 ToVector4()
         {
             return new Vector4(
@@ -70,51 +77,64 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
         }
 
         /// <summary>
-        /// Compares an object with the packed vector.
+        /// Returns a value that indicates whether this <see cref="Alpha8"/>
+        /// and a specified object are equal.
         /// </summary>
-        /// <param name="obj">The object to compare.</param>
-        /// <returns>True if the object is equal to the packed vector.</returns>
+        /// <param name="obj">The object to compare with this <see cref="Alpha8"/>.</param>
+        /// <returns>
+        /// <see langword="true"/> if this <see cref="Alpha8"/> and
+        /// <paramref name="obj"/> are equal; otherwise, <see langword="false"/>.
+        /// </returns>
         public override bool Equals(object obj)
         {
             return (obj is Alpha8) && Equals((Alpha8) obj);
         }
 
         /// <summary>
-        /// Compares another Alpha8 packed vector with the packed vector.
+        /// Returns a value tha indicates whether this <see cref="Alpha8"/>
+        /// and a specified <see cref="Alpha8"/> are equal.
         /// </summary>
-        /// <param name="other">The Alpha8 packed vector to compare.</param>
-        /// <returns>True if the packed vectors are equal.</returns>
+        /// <param name="other">The other <see cref="Alpha8"/>.</param>
+        /// <returns>
+        /// <see langword="true"/> if the two <see cref="Alpha8"/> values
+        /// are equal; otherwise, <see langword="false"/>.
+        /// </returns>
         public bool Equals(Alpha8 other)
         {
             return packedValue == other.packedValue;
         }
 
         /// <summary>
-        /// Gets a string representation of the packed vector.
+        /// Returns the string representation of this <see cref="Alpha8"/> value.
         /// </summary>
-        /// <returns>A string representation of the packed vector.</returns>
+        /// <returns>
+        /// The string representation of this <see cref="Alpha8"/> value.
+        /// </returns>
         public override string ToString()
         {
             return (packedValue / 255.0f).ToString();
         }
 
         /// <summary>
-        /// Gets a hash code of the packed vector.
+        /// Returns the hash code for this <see cref="Alpha8"/> value.
         /// </summary>
-        /// <returns>The hash code for the packed vector.</returns>
+        /// <returns>
+        /// The 32-bit signed integer hash code for this <see cref="Alpha8"/> value.
+        /// </returns>
         public override int GetHashCode()
         {
             return packedValue.GetHashCode();
         }
 
         /// <summary>
-        /// Compares the current instance of a class to another instance to determine
-        /// whether they are the same.
+        /// Returns a value that indicates whether two <see cref="Alpha8"/>
+        /// values are equal.
         /// </summary>
-        /// <param name="lhs">The object on the left of the equality operator.</param>
-        /// <param name="rhs">The object on the right of the equality operator.</param>
+        /// <param name="lhs">The <see cref="Alpha8"/> on the left of the equality operator.</param>
+        /// <param name="rhs">The <see cref="Alpha8"/> on the right of the equality operator.</param>
         /// <returns>
-        /// <see langword="true"/> if the objects are the same; <see langword="false"/> otherwise.
+        /// <see langword="true"/> if <paramref name="lhs"/> and <paramref name="rhs"/>
+        /// are equal; otherwise, <see langword="false"/>.
         /// </returns>
         public static bool operator ==(Alpha8 lhs, Alpha8 rhs)
         {
@@ -122,13 +142,14 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
         }
 
         /// <summary>
-        /// Compares teh current instance of a class to another instance to determine
-        /// whether they are different.
+        /// Returns a value that indicates whether two <see cref="Alpha8"/>
+        /// values are not equal.
         /// </summary>
-        /// <param name="lhs">The object to the left of the inequality operator.</param>
-        /// <param name="rhs">The object to the right of the inequality operator.</param>
+        /// <param name="lhs">The <see cref="Alpha8"/> on the left of the inequality operator.</param>
+        /// <param name="rhs">The <see cref="Alpha8"/> on the right of the inequality operator.</param>
         /// <returns>
-        /// <see langword="true"/> if the objects are different; <see langword="false"/> otherwise.
+        /// <see langword="true"/> if <paramref name="lhs"/> and <paramref name="rhs"/>
+        /// are different; otherwise, <see langword="false"/>.
         /// </returns>
         public static bool operator !=(Alpha8 lhs, Alpha8 rhs)
         {

--- a/MonoGame.Framework/Graphics/PackedVector/Bgr565.cs
+++ b/MonoGame.Framework/Graphics/PackedVector/Bgr565.cs
@@ -21,28 +21,34 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
         }
 
         /// <summary>
-        /// Creates a new instance of Bgr565.
+        /// Creates a new <see cref="Bgr565"/> from the specified component values.
         /// </summary>
-        /// <param name="x">The x component</param>
-        /// <param name="y">The y component</param>
-        /// <param name="z">The z component</param>
+        /// <param name="x">The initial x-component value.</param>
+        /// <param name="y">The initial y-component value.</param>
+        /// <param name="z">The initial z-component value.</param>
         public Bgr565(float x, float y, float z)
         {
             _packedValue = Pack(x, y, z);
         }
 
         /// <summary>
-        /// Creates a new instance of Bgr565.
+        /// Creates a new <see cref="Bgr565"/> from the specified <see cref="Vector3"/>.
         /// </summary>
-        /// <param name="vector">Vector containing the components for the packed vector.</param>
+        /// <param name="vector">
+        /// The <see cref="Vector3"/> whos components contain the initial values
+        /// for this <see cref="Bgr565"/>.
+        /// </param>
         public Bgr565(Vector3 vector)
         {
             _packedValue = Pack(vector.X, vector.Y, vector.Z);
         }
 
         /// <summary>
-        /// Gets and sets the packed value.
+        /// Gets or Sets the packed representation of this <see cref="Bgr565"/>.
         /// </summary>
+        /// <value>
+        /// The packed representation of this <see cref="Bgr565"/>
+        /// </value>
         public UInt16 PackedValue
         {
             get
@@ -56,9 +62,11 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
         }
 
         /// <summary>
-        /// Gets the packed vector in Vector3 format.
+        /// Expands this <see cref="Bgr565"/> to a <see cref="Vector3"/>
         /// </summary>
-        /// <returns>The packed vector in Vector3 format</returns>
+        /// <returns>
+        /// The expanded <see cref="Bgr565"/> as a <see cref="Vector3"/>.
+        /// </returns>
         public Vector3 ToVector3()
         {
             return new Vector3((float)(((_packedValue >> 11) & 0x1F) * (1.0f / 31.0f)),
@@ -79,19 +87,25 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
         }
 
         /// <summary>
-        /// Gets the packed vector in Vector4 format.
+        /// Expands this <see cref="Bgr565"/> to a <see cref="Vector4"/>
         /// </summary>
-        /// <returns>The packed vector in Vector4 format</returns>
+        /// <returns>
+        /// The expanded <see cref="Bgr565"/> as a <see cref="Vector4"/>.
+        /// </returns>
         public Vector4 ToVector4()
         {
             return new Vector4(ToVector3(), 1.0f);
         }
 
         /// <summary>
-        /// Compares an object with the packed vector.
+        /// Returns a value that indicates whether this <see cref="Bgr565"/>
+        /// and a specified object are equal.
         /// </summary>
-        /// <param name="obj">The object to compare.</param>
-        /// <returns>true if the object is equal to the packed vector.</returns>
+        /// <param name="obj">The object to compare with this <see cref="Bgr565"/>.</param>
+        /// <returns>
+        /// <see langword="true"/> if this <see cref="Bgr565"/> and
+        /// <paramref name="obj"/> are equal; otherwise, <see langword="false"/>.
+        /// </returns>
         public override bool Equals(object obj)
         {
             if (obj != null && (obj is Bgr565))
@@ -100,28 +114,36 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
         }
 
         /// <summary>
-        /// Compares another Bgr565 packed vector with the packed vector.
+        /// Returns a value tha indicates whether this <see cref="Bgr565"/>
+        /// and a specified <see cref="Bgr565"/> are equal.
         /// </summary>
-        /// <param name="other">The Bgr565 packed vector to compare.</param>
-        /// <returns>true if the packed vectors are equal.</returns>
+        /// <param name="other">The other <see cref="Bgr565"/>.</param>
+        /// <returns>
+        /// <see langword="true"/> if the two <see cref="Bgr565"/> values
+        /// are equal; otherwise, <see langword="false"/>.
+        /// </returns>
         public bool Equals(Bgr565 other)
         {
             return _packedValue == other._packedValue;
         }
 
         /// <summary>
-        /// Gets a string representation of the packed vector.
+        /// Returns the string representation of this <see cref="Bgr565"/> value.
         /// </summary>
-        /// <returns>A string representation of the packed vector.</returns>
+        /// <returns>
+        /// The string representation of this <see cref="Bgr565"/> value.
+        /// </returns>
         public override string ToString()
         {
             return ToVector3().ToString();
         }
 
         /// <summary>
-        /// Gets a hash code of the packed vector.
+        /// Returns the hash code for this <see cref="Bgr565"/> value.
         /// </summary>
-        /// <returns>The hash code for the packed vector.</returns>
+        /// <returns>
+        /// The 32-bit signed integer hash code for this <see cref="Bgr565"/> value.
+        /// </returns>
         public override int GetHashCode()
         {
             return _packedValue.GetHashCode();

--- a/MonoGame.Framework/Graphics/PackedVector/Bgra4444.cs
+++ b/MonoGame.Framework/Graphics/PackedVector/Bgra4444.cs
@@ -22,29 +22,35 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
         }
 
         /// <summary>
-        /// Creates a new instance of Bgra4444.
+        /// Creates a new <see cref="Bgra4444"/> from the specified component values.
         /// </summary>
-        /// <param name="x">The x component</param>
-        /// <param name="y">The y component</param>
-        /// <param name="z">The z component</param>
-        /// <param name="w">The w component</param>
+        /// <param name="x">The initial x-component value.</param>
+        /// <param name="y">The initial y-component value.</param>
+        /// <param name="z">The initial z-component value.</param>
+        /// <param name="w">The initial w-component value.</param>
         public Bgra4444(float x, float y, float z, float w)
         {
             _packedValue = Pack(x, y, z, w);
         }
 
         /// <summary>
-        /// Creates a new instance of Bgra4444.
+        /// Creates a new <see cref="Bgra4444"/> from the specified <see cref="Vector4"/>.
         /// </summary>
-        /// <param name="vector">Vector containing the components for the packed vector.</param>
+        /// <param name="vector">
+        /// The <see cref="Vector4"/> whos components contain the initial values
+        /// for this <see cref="Bgra4444"/>.
+        /// </param>
         public Bgra4444(Vector4 vector)
         {
             _packedValue = Pack(vector.X, vector.Y, vector.Z, vector.W);
         }
 
         /// <summary>
-        /// Gets and sets the packed value.
+        /// Gets or Sets the packed representation of this <see cref="Bgra4444"/>.
         /// </summary>
+        /// <value>
+        /// The packed representation of this <see cref="Bgra4444"/>
+        /// </value>
         public UInt16 PackedValue
         {
             get
@@ -58,9 +64,11 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
         }
 
         /// <summary>
-        /// Gets the packed vector in Vector4 format.
+        /// Expands this <see cref="Bgra4444"/> to a <see cref="Vector4"/>
         /// </summary>
-        /// <returns>The packed vector in Vector4 format</returns>
+        /// <returns>
+        /// The expanded <see cref="Bgra4444"/> as a <see cref="Vector4"/>.
+        /// </returns>
         public Vector4 ToVector4()
         {
             const float maxVal = 1 / 15.0f;
@@ -81,10 +89,14 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
         }
 
         /// <summary>
-        /// Compares an object with the packed vector.
+        /// Returns a value that indicates whether this <see cref="Bgra4444"/>
+        /// and a specified object are equal.
         /// </summary>
-        /// <param name="obj">The object to compare.</param>
-        /// <returns>true if the object is equal to the packed vector.</returns>
+        /// <param name="obj">The object to compare with this <see cref="Bgra4444"/>.</param>
+        /// <returns>
+        /// <see langword="true"/> if this <see cref="Bgra4444"/> and
+        /// <paramref name="obj"/> are equal; otherwise, <see langword="false"/>.
+        /// </returns>
         public override bool Equals(object obj)
         {
             if (obj != null && (obj is Bgra4444))
@@ -93,28 +105,36 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
         }
 
         /// <summary>
-        /// Compares another Bgra4444 packed vector with the packed vector.
+        /// Returns a value tha indicates whether this <see cref="Bgra4444"/>
+        /// and a specified <see cref="Bgra4444"/> are equal.
         /// </summary>
-        /// <param name="other">The Bgra4444 packed vector to compare.</param>
-        /// <returns>true if the packed vectors are equal.</returns>
+        /// <param name="other">The other <see cref="Bgra4444"/>.</param>
+        /// <returns>
+        /// <see langword="true"/> if the two <see cref="Bgra4444"/> values
+        /// are equal; otherwise, <see langword="false"/>.
+        /// </returns>
         public bool Equals(Bgra4444 other)
         {
             return _packedValue == other._packedValue;
         }
 
         /// <summary>
-        /// Gets a string representation of the packed vector.
+        /// Returns the string representation of this <see cref="Bgra4444"/> value.
         /// </summary>
-        /// <returns>A string representation of the packed vector.</returns>
+        /// <returns>
+        /// The string representation of this <see cref="Bgra4444"/> value.
+        /// </returns>
         public override string ToString()
         {
             return ToVector4().ToString();
         }
 
         /// <summary>
-        /// Gets a hash code of the packed vector.
+        /// Returns the hash code for this <see cref="Bgra4444"/> value.
         /// </summary>
-        /// <returns>The hash code for the packed vector.</returns>
+        /// <returns>
+        /// The 32-bit signed integer hash code for this <see cref="Bgra4444"/> value.
+        /// </returns>
         public override int GetHashCode()
         {
             return _packedValue.GetHashCode();

--- a/MonoGame.Framework/Graphics/PackedVector/Bgra5551.cs
+++ b/MonoGame.Framework/Graphics/PackedVector/Bgra5551.cs
@@ -13,8 +13,11 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
     public struct Bgra5551 : IPackedVector<UInt16>, IEquatable<Bgra5551>, IPackedVector
     {
         /// <summary>
-        /// Gets and sets the packed value.
+        /// Gets or Sets the packed representation of this <see cref="Bgra5551"/>.
         /// </summary>
+        /// <value>
+        /// The packed representation of this <see cref="Bgra5551"/>
+        /// </value>
         public UInt16 PackedValue
         {
             get
@@ -30,22 +33,23 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
         private UInt16 packedValue;
 
         /// <summary>
-        /// Creates a new instance of Bgra5551.
+        /// Creates a new <see cref="Bgra5551"/> from the specified component values.
         /// </summary>
-        /// <param name="x">The x component</param>
-        /// <param name="y">The y component</param>
-        /// <param name="z">The z component</param>
-        /// <param name="w">The w component</param>
+        /// <param name="x">The initial x-component value.</param>
+        /// <param name="y">The initial y-component value.</param>
+        /// <param name="z">The initial z-component value.</param>
+        /// <param name="w">The initial w-component value.</param>
         public Bgra5551(float x, float y, float z, float w)
         {
             packedValue = Pack(x, y, z, w);
         }
 
         /// <summary>
-        /// Creates a new instance of Bgra5551.
+        /// Creates a new <see cref="Bgra5551"/> from the specified <see cref="Vector4"/>.
         /// </summary>
         /// <param name="vector">
-        /// Vector containing the components for the packed vector.
+        /// The <see cref="Vector4"/> whos components contain the initial values
+        /// for this <see cref="Bgra5551"/>.
         /// </param>
         public Bgra5551(Vector4 vector)
         {
@@ -53,9 +57,11 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
         }
 
         /// <summary>
-        /// Gets the packed vector in Vector4 format.
+        /// Expands this <see cref="Bgra5551"/> to a <see cref="Vector4"/>
         /// </summary>
-        /// <returns>The packed vector in Vector4 format</returns>
+        /// <returns>
+        /// The expanded <see cref="Bgra5551"/> as a <see cref="Vector4"/>.
+        /// </returns>
         public Vector4 ToVector4()
         {
             return new Vector4(
@@ -76,38 +82,50 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
         }
 
         /// <summary>
-        /// Compares an object with the packed vector.
+        /// Returns a value that indicates whether this <see cref="Bgra5551"/>
+        /// and a specified object are equal.
         /// </summary>
-        /// <param name="obj">The object to compare.</param>
-        /// <returns>True if the object is equal to the packed vector.</returns>
+        /// <param name="obj">The object to compare with this <see cref="Bgra5551"/>.</param>
+        /// <returns>
+        /// <see langword="true"/> if this <see cref="Bgra5551"/> and
+        /// <paramref name="obj"/> are equal; otherwise, <see langword="false"/>.
+        /// </returns>
         public override bool Equals(object obj)
         {
             return (obj is Bgra5551) && Equals((Bgra5551) obj);
         }
 
         /// <summary>
-        /// Compares another Bgra5551 packed vector with the packed vector.
+        /// Returns a value tha indicates whether this <see cref="Bgra5551"/>
+        /// and a specified <see cref="Bgra5551"/> are equal.
         /// </summary>
-        /// <param name="other">The Bgra5551 packed vector to compare.</param>
-        /// <returns>True if the packed vectors are equal.</returns>
+        /// <param name="other">The other <see cref="Bgra5551"/>.</param>
+        /// <returns>
+        /// <see langword="true"/> if the two <see cref="Bgra5551"/> values
+        /// are equal; otherwise, <see langword="false"/>.
+        /// </returns>
         public bool Equals(Bgra5551 other)
         {
             return packedValue == other.packedValue;
         }
 
         /// <summary>
-        /// Gets a string representation of the packed vector.
+        /// Returns the string representation of this <see cref="Bgra5551"/> value.
         /// </summary>
-        /// <returns>A string representation of the packed vector.</returns>
+        /// <returns>
+        /// The string representation of this <see cref="Bgra5551"/> value.
+        /// </returns>
         public override string ToString()
         {
             return ToVector4().ToString();
         }
 
         /// <summary>
-        /// Gets a hash code of the packed vector.
+        /// Returns the hash code for this <see cref="Bgra5551"/> value.
         /// </summary>
-        /// <returns>The hash code for the packed vector.</returns>
+        /// <returns>
+        /// The 32-bit signed integer hash code for this <see cref="Bgra5551"/> value.
+        /// </returns>
         public override int GetHashCode()
         {
             return packedValue.GetHashCode();

--- a/MonoGame.Framework/Graphics/PackedVector/Byte4.cs
+++ b/MonoGame.Framework/Graphics/PackedVector/Byte4.cs
@@ -14,21 +14,24 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
         uint packedValue;
 
         /// <summary>
-        /// Initializes a new instance of the Byte4 class.
+        /// Creates a new <see cref="Byte4"/> from the specified <see cref="Vector4"/>.
         /// </summary>
-        /// <param name="vector">A vector containing the initial values for the components of the Byte4 structure.</param>
+        /// <param name="vector">
+        /// The <see cref="Vector4"/> whos components contain the initial values
+        /// for this <see cref="Byte4"/>.
+        /// </param>
         public Byte4(Vector4 vector)
         {
             packedValue = Pack(ref vector);
         }
 
         /// <summary>
-        /// Initializes a new instance of the Byte4 class.
+        /// Creates a new <see cref="Byte4"/> from the specified component values.
         /// </summary>
-        /// <param name="x">Initial value for the x component.</param>
-        /// <param name="y">Initial value for the y component.</param>
-        /// <param name="z">Initial value for the z component.</param>
-        /// <param name="w">Initial value for the w component.</param>
+        /// <param name="x">The initial x-component value.</param>
+        /// <param name="y">The initial y-component value.</param>
+        /// <param name="z">The initial z-component value.</param>
+        /// <param name="w">The initial w-component value.</param>
         public Byte4(float x, float y, float z, float w)
         {
             var vector = new Vector4(x, y, z, w);
@@ -36,31 +39,41 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
         }
 
         /// <summary>
-        /// Compares the current instance of a class to another instance to determine whether they are different.
+        /// Returns a value that indicates whether two <see cref="Byte4"/>
+        /// values are not equal.
         /// </summary>
-        /// <param name="a">The object to the left of the equality operator.</param>
-        /// <param name="b">The object to the right of the equality operator.</param>
-        /// <returns>true if the objects are different; false otherwise.</returns>
+        /// <param name="a">The <see cref="Byte4"/> on the left of the inequality operator.</param>
+        /// <param name="b">The <see cref="Byte4"/> on the right of the inequality operator.</param>
+        /// <returns>
+        /// <see langword="true"/> if <paramref name="a"/> and <paramref name="b"/>
+        /// are different; otherwise, <see langword="false"/>.
+        /// </returns>
         public static bool operator !=(Byte4 a, Byte4 b)
         {
             return a.PackedValue != b.PackedValue;
         }
 
         /// <summary>
-        /// Compares the current instance of a class to another instance to determine whether they are the same.
+        /// Returns a value that indicates whether two <see cref="Byte4"/>
+        /// values are equal.
         /// </summary>
-        /// <param name="a">The object to the left of the equality operator.</param>
-        /// <param name="b">The object to the right of the equality operator.</param>
-        /// <returns>true if the objects are the same; false otherwise.</returns>
+        /// <param name="a">The <see cref="Byte4"/> on the left of the equality operator.</param>
+        /// <param name="b">The <see cref="Byte4"/> on the right of the equality operator.</param>
+        /// <returns>
+        /// <see langword="true"/> if <paramref name="a"/> and <paramref name="b"/>
+        /// are equal; otherwise, <see langword="false"/>.
+        /// </returns>
         public static bool operator ==(Byte4 a, Byte4 b)
         {
             return a.PackedValue == b.PackedValue;
         }
 
         /// <summary>
-        /// Directly gets or sets the packed representation of the value.
+        /// Gets or Sets the packed representation of this <see cref="Byte4"/>.
         /// </summary>
-        /// <value>The packed representation of the value.</value>
+        /// <value>
+        /// The packed representation of this <see cref="Byte4"/>
+        /// </value>
         public uint PackedValue
         {
             get
@@ -74,10 +87,14 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
         }
 
         /// <summary>
-        /// Returns a value that indicates whether the current instance is equal to a specified object.
+        /// Returns a value that indicates whether this <see cref="Byte4"/>
+        /// and a specified object are equal.
         /// </summary>
-        /// <param name="obj">The object with which to make the comparison.</param>
-        /// <returns>true if the current instance is equal to the specified object; false otherwise.</returns>
+        /// <param name="obj">The object to compare with this <see cref="Byte4"/>.</param>
+        /// <returns>
+        /// <see langword="true"/> if this <see cref="Byte4"/> and
+        /// <paramref name="obj"/> are equal; otherwise, <see langword="false"/>.
+        /// </returns>
         public override bool Equals(object obj)
         {
             if (obj is Byte4)
@@ -86,28 +103,36 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
         }
 
         /// <summary>
-        /// Returns a value that indicates whether the current instance is equal to a specified object.
+        /// Returns a value tha indicates whether this <see cref="Byte4"/>
+        /// and a specified <see cref="Byte4"/> are equal.
         /// </summary>
-        /// <param name="other">The object with which to make the comparison.</param>
-        /// <returns>true if the current instance is equal to the specified object; false otherwise.</returns>
+        /// <param name="other">The other <see cref="Byte4"/>.</param>
+        /// <returns>
+        /// <see langword="true"/> if the two <see cref="Byte4"/> values
+        /// are equal; otherwise, <see langword="false"/>.
+        /// </returns>
         public bool Equals(Byte4 other)
         {
             return this == other;
         }
 
         /// <summary>
-        /// Gets the hash code for the current instance.
+        /// Returns the hash code for this <see cref="Byte4"/> value.
         /// </summary>
-        /// <returns>Hash code for the instance.</returns>
+        /// <returns>
+        /// The 32-bit signed integer hash code for this <see cref="Byte4"/> value.
+        /// </returns>
         public override int GetHashCode()
         {
             return packedValue.GetHashCode();
         }
 
         /// <summary>
-        /// Returns a string representation of the current instance.
+        /// Returns the string representation of this <see cref="Byte4"/> value.
         /// </summary>
-        /// <returns>String that represents the object.</returns>
+        /// <returns>
+        /// The string representation of this <see cref="Byte4"/> value.
+        /// </returns>
         public override string ToString()
         {
             return packedValue.ToString("x8");
@@ -142,9 +167,11 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
         }
 
         /// <summary>
-        /// Expands the packed representation into a Vector4.
+        /// Expands this <see cref="Byte4"/> to a <see cref="Vector4"/>
         /// </summary>
-        /// <returns>The expanded vector.</returns>
+        /// <returns>
+        /// The expanded <see cref="Byte4"/> as a <see cref="Vector4"/>.
+        /// </returns>
         public Vector4 ToVector4()
         {
             return new Vector4(

--- a/MonoGame.Framework/Graphics/PackedVector/HalfVector2.cs
+++ b/MonoGame.Framework/Graphics/PackedVector/HalfVector2.cs
@@ -62,9 +62,11 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
         }
 
         /// <summary>
-        /// Gets the packed vector in Vector4 format.
+        /// Expands this <see cref="HalfVector2"/> to a <see cref="Vector4"/>
         /// </summary>
-        /// <returns>The packed vector in Vector4 format</returns>
+        /// <returns>
+        /// The expanded <see cref="HalfVector2"/> as a <see cref="Vector4"/>.
+        /// </returns>
         public Vector4 ToVector4()
         {
             Vector2 vector = this.ToVector2();

--- a/MonoGame.Framework/Graphics/PackedVector/HalfVector4.cs
+++ b/MonoGame.Framework/Graphics/PackedVector/HalfVector4.cs
@@ -14,12 +14,12 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
         ulong packedValue;
 
         /// <summary>
-        /// Initializes a new instance of the HalfVector4 structure.
+        /// Creates a new <see cref="HalfVector4"/> from the specified component values.
         /// </summary>
-        /// <param name="x">Initial value for the x component.</param>
-        /// <param name="y">Initial value for the y component.</param>
-        /// <param name="z">Initial value for the z component.</param>
-        /// <param name="w">Initial value for the q component.</param>
+        /// <param name="x">The initial x-component value.</param>
+        /// <param name="y">The initial y-component value.</param>
+        /// <param name="z">The initial z-component value.</param>
+        /// <param name="w">The initial w-component value.</param>
         public HalfVector4(float x, float y, float z, float w)
         {
             var vector = new Vector4(x, y, z, w);
@@ -27,9 +27,12 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
         }
 
         /// <summary>
-        /// Initializes a new instance of the HalfVector4 structure.
+        /// Creates a new <see cref="HalfVector4"/> from the specified <see cref="Vector4"/>.
         /// </summary>
-        /// <param name="vector">A vector containing the initial values for the components of the HalfVector4 structure.</param>
+        /// <param name="vector">
+        /// The <see cref="Vector4"/> whos components contain the initial values
+        /// for this <see cref="HalfVector4"/>.
+        /// </param>
         public HalfVector4(Vector4 vector)
         {
             packedValue = PackHelper(ref vector);
@@ -59,9 +62,11 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
         }
 
         /// <summary>
-        /// Expands the packed representation into a Vector4.
+        /// Expands this <see cref="HalfVector4"/> to a <see cref="Vector4"/>
         /// </summary>
-        /// <returns>The expanded vector.</returns>
+        /// <returns>
+        /// The expanded <see cref="HalfVector4"/> as a <see cref="Vector4"/>.
+        /// </returns>
         public Vector4 ToVector4()
         {
             return new Vector4(
@@ -72,9 +77,11 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
         }
 
         /// <summary>
-        /// Directly gets or sets the packed representation of the value.
+        /// Gets or Sets the packed representation of this <see cref="HalfVector4"/>.
         /// </summary>
-        /// <value>The packed representation of the value.</value>
+        /// <value>
+        /// The packed representation of this <see cref="HalfVector4"/>
+        /// </value>
         public ulong PackedValue
         {
             get
@@ -88,60 +95,80 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
         }
 
         /// <summary>
-        /// Returns a string representation of the current instance.
+        /// Returns the string representation of this <see cref="HalfVector4"/> value.
         /// </summary>
-        /// <returns>String that represents the object.</returns>
+        /// <returns>
+        /// The string representation of this <see cref="HalfVector4"/> value.
+        /// </returns>
         public override string ToString()
         {
             return ToVector4().ToString();
         }
 
         /// <summary>
-        /// Gets the hash code for the current instance.
+        /// Returns the hash code for this <see cref="HalfVector4"/> value.
         /// </summary>
-        /// <returns>Hash code for the instance.</returns>
+        /// <returns>
+        /// The 32-bit signed integer hash code for this <see cref="HalfVector4"/> value.
+        /// </returns>
         public override int GetHashCode()
         {
             return packedValue.GetHashCode();
         }
 
         /// <summary>
-        /// Returns a value that indicates whether the current instance is equal to a specified object.
+        /// Returns a value that indicates whether this <see cref="HalfVector4"/>
+        /// and a specified object are equal.
         /// </summary>
-        /// <param name="obj">The object with which to make the comparison.</param>
-        /// <returns>true if the current instance is equal to the specified object; false otherwise.</returns>
+        /// <param name="obj">The object to compare with this <see cref="HalfVector4"/>.</param>
+        /// <returns>
+        /// <see langword="true"/> if this <see cref="HalfVector4"/> and
+        /// <paramref name="obj"/> are equal; otherwise, <see langword="false"/>.
+        /// </returns>
         public override bool Equals(object obj)
         {
             return ((obj is HalfVector4) && Equals((HalfVector4)obj));
         }
 
         /// <summary>
-        /// Returns a value that indicates whether the current instance is equal to a specified object.
+        /// Returns a value tha indicates whether this <see cref="HalfVector4"/>
+        /// and a specified <see cref="HalfVector4"/> are equal.
         /// </summary>
-        /// <param name="other">The object with which to make the comparison.</param>
-        /// <returns>true if the current instance is equal to the specified object; false otherwise.</returns>
+        /// <param name="other">The other <see cref="HalfVector4"/>.</param>
+        /// <returns>
+        /// <see langword="true"/> if the two <see cref="HalfVector4"/> values
+        /// are equal; otherwise, <see langword="false"/>.
+        /// </returns>
         public bool Equals(HalfVector4 other)
         {
             return packedValue.Equals(other.packedValue);
         }
 
         /// <summary>
-        /// Compares the current instance of a class to another instance to determine whether they are the same.
+        /// Returns a value that indicates whether two <see cref="HalfVector4"/>
+        /// values are equal.
         /// </summary>
-        /// <param name="a">The object to the left of the equality operator.</param>
-        /// <param name="b">The object to the right of the equality operator.</param>
-        /// <returns>true if the objects are the same; false otherwise.</returns>
+        /// <param name="a">The <see cref="HalfVector4"/> on the left of the equality operator.</param>
+        /// <param name="b">The <see cref="HalfVector4"/> on the right of the equality operator.</param>
+        /// <returns>
+        /// <see langword="true"/> if <paramref name="a"/> and <paramref name="b"/>
+        /// are equal; otherwise, <see langword="false"/>.
+        /// </returns>
         public static bool operator ==(HalfVector4 a, HalfVector4 b)
         {
             return a.Equals(b);
         }
 
         /// <summary>
-        /// Compares the current instance of a class to another instance to determine whether they are different.
+        /// Returns a value that indicates whether two <see cref="HalfVector4"/>
+        /// values are not equal.
         /// </summary>
-        /// <param name="a">The object to the left of the equality operator.</param>
-        /// <param name="b">The object to the right of the equality operator.</param>
-        /// <returns>true if the objects are different; false otherwise.</returns>
+        /// <param name="a">The <see cref="HalfVector4"/> on the left of the inequality operator.</param>
+        /// <param name="b">The <see cref="HalfVector4"/> on the right of the inequality operator.</param>
+        /// <returns>
+        /// <see langword="true"/> if <paramref name="a"/> and <paramref name="b"/>
+        /// are different; otherwise, <see langword="false"/>.
+        /// </returns>
         public static bool operator !=(HalfVector4 a, HalfVector4 b)
         {
             return !a.Equals(b);

--- a/MonoGame.Framework/Graphics/PackedVector/NormalizedByte2.cs
+++ b/MonoGame.Framework/Graphics/PackedVector/NormalizedByte2.cs
@@ -149,9 +149,11 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
         }
 
         /// <summary>
-        /// Gets the packed vector in Vector4 format.
+        /// Expands this <see cref="NormalizedByte2"/> to a <see cref="Vector4"/>
         /// </summary>
-        /// <returns>The packed vector in Vector4 format</returns>
+        /// <returns>
+        /// The expanded <see cref="NormalizedByte2"/> as a <see cref="Vector4"/>.
+        /// </returns>
         public Vector4 ToVector4()
         {
             return new Vector4(ToVector2(), 0.0f, 1.0f);

--- a/MonoGame.Framework/Graphics/PackedVector/Rg32.cs
+++ b/MonoGame.Framework/Graphics/PackedVector/Rg32.cs
@@ -12,8 +12,11 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
     public struct Rg32 : IPackedVector<uint>, IEquatable<Rg32>, IPackedVector
     {
         /// <summary>
-        /// Gets and sets the packed value.
+        /// Gets or Sets the packed representation of this <see cref="Rg32"/>.
         /// </summary>
+        /// <value>
+        /// The packed representation of this <see cref="Rg32"/>
+        /// </value>
         public uint PackedValue
         {
             get
@@ -29,20 +32,21 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
         private uint packedValue;
 
         /// <summary>
-        /// Creates a new instance of Rg32.
+        /// Creates a new <see cref="Rg32"/> from the specified component values.
         /// </summary>
-        /// <param name="x">The x component</param>
-        /// <param name="y">The y component</param>
+        /// <param name="x">The initial x-component value.</param>
+        /// <param name="y">The initial y-component value.</param>
         public Rg32(float x, float y)
         {
             packedValue = Pack(x, y);
         }
 
         /// <summary>
-        /// Creates a new instance of Rg32.
+        /// Creates a new <see cref="Rg32"/> from the specified <see cref="Vector2"/>.
         /// </summary>
         /// <param name="vector">
-        /// Vector containing the components for the packed vector.
+        /// The <see cref="Vector2"/> whos components contain the initial values
+        /// for this <see cref="Rg32"/>.
         /// </param>
         public Rg32(Vector2 vector)
         {
@@ -50,9 +54,11 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
         }
 
         /// <summary>
-        /// Gets the packed vector in Vector2 format.
+        /// Expands this <see cref="Rg32"/> to a <see cref="Vector2"/>
         /// </summary>
-        /// <returns>The packed vector in Vector2 format</returns>
+        /// <returns>
+        /// The expanded <see cref="Rg32"/> as a <see cref="Vector2"/>.
+        /// </returns>
         public Vector2 ToVector2()
         {
             return new Vector2(
@@ -71,47 +77,61 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
         }
 
         /// <summary>
-        /// Gets the packed vector in Vector4 format.
+        /// Expands this <see cref="Rg32"/> to a <see cref="Vector4"/>
         /// </summary>
-        /// <returns>The packed vector in Vector4 format</returns>
+        /// <returns>
+        /// The expanded <see cref="Rg32"/> as a <see cref="Vector4"/>.
+        /// </returns>
         public Vector4 ToVector4()
         {
             return new Vector4(ToVector2(), 0.0f, 1.0f);
         }
 
         /// <summary>
-        /// Compares an object with the packed vector.
+        /// Returns a value that indicates whether this <see cref="Rg32"/>
+        /// and a specified object are equal.
         /// </summary>
-        /// <param name="obj">The object to compare.</param>
-        /// <returns>True if the object is equal to the packed vector.</returns>
+        /// <param name="obj">The object to compare with this <see cref="Rg32"/>.</param>
+        /// <returns>
+        /// <see langword="true"/> if this <see cref="Rg32"/> and
+        /// <paramref name="obj"/> are equal; otherwise, <see langword="false"/>.
+        /// </returns>
         public override bool Equals(object obj)
         {
             return (obj is Rg32) && Equals((Rg32) obj);
         }
 
         /// <summary>
-        /// Compares another Rg32 packed vector with the packed vector.
+        /// Returns a value tha indicates whether this <see cref="Rg32"/>
+        /// and a specified <see cref="Rg32"/> are equal.
         /// </summary>
-        /// <param name="other">The Rg32 packed vector to compare.</param>
-        /// <returns>True if the packed vectors are equal.</returns>
+        /// <param name="other">The other <see cref="Rg32"/>.</param>
+        /// <returns>
+        /// <see langword="true"/> if the two <see cref="Rg32"/> values
+        /// are equal; otherwise, <see langword="false"/>.
+        /// </returns>
         public bool Equals(Rg32 other)
         {
             return packedValue == other.packedValue;
         }
 
         /// <summary>
-        /// Gets a string representation of the packed vector.
+        /// Returns the string representation of this <see cref="Rg32"/> value.
         /// </summary>
-        /// <returns>A string representation of the packed vector.</returns>
+        /// <returns>
+        /// The string representation of this <see cref="Rg32"/> value.
+        /// </returns>
         public override string ToString()
         {
             return ToVector2().ToString();
         }
 
         /// <summary>
-        /// Gets a hash code of the packed vector.
+        /// Returns the hash code for this <see cref="Rg32"/> value.
         /// </summary>
-        /// <returns>The hash code for the packed vector.</returns>
+        /// <returns>
+        /// The 32-bit signed integer hash code for this <see cref="Rg32"/> value.
+        /// </returns>
         public override int GetHashCode()
         {
             return packedValue.GetHashCode();

--- a/MonoGame.Framework/Graphics/PackedVector/Rgba1010102.cs
+++ b/MonoGame.Framework/Graphics/PackedVector/Rgba1010102.cs
@@ -13,8 +13,11 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
     public struct Rgba1010102 : IPackedVector<uint>, IEquatable<Rgba1010102>, IPackedVector
     {
         /// <summary>
-        /// Gets and sets the packed value.
+        /// Gets or Sets the packed representation of this <see cref="Rgba1010102"/>.
         /// </summary>
+        /// <value>
+        /// The packed representation of this <see cref="Rgba1010102"/>
+        /// </value>
         public uint PackedValue
         {
             get
@@ -30,22 +33,23 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
         private uint packedValue;
 
         /// <summary>
-        /// Creates a new instance of Rgba1010102.
+        /// Creates a new <see cref="Rgba1010102"/> from the specified component values.
         /// </summary>
-        /// <param name="x">The x component</param>
-        /// <param name="y">The y component</param>
-        /// <param name="z">The z component</param>
-        /// <param name="w">The w component</param>
+        /// <param name="x">The initial x-component value.</param>
+        /// <param name="y">The initial y-component value.</param>
+        /// <param name="z">The initial z-component value.</param>
+        /// <param name="w">The initial w-component value.</param>
         public Rgba1010102(float x, float y, float z, float w)
         {
             packedValue = Pack(x, y, z, w);
         }
 
         /// <summary>
-        /// Creates a new instance of Rgba1010102.
+        /// Creates a new <see cref="Rgba1010102"/> from the specified <see cref="Vector4"/>.
         /// </summary>
         /// <param name="vector">
-        /// Vector containing the components for the packed vector.
+        /// The <see cref="Vector4"/> whos components contain the initial values
+        /// for this <see cref="Rgba1010102"/>.
         /// </param>
         public Rgba1010102(Vector4 vector)
         {
@@ -53,9 +57,11 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
         }
 
         /// <summary>
-        /// Gets the packed vector in Vector4 format.
+        /// Expands this <see cref="Rgba1010102"/> to a <see cref="Vector4"/>
         /// </summary>
-        /// <returns>The packed vector in Vector4 format</returns>
+        /// <returns>
+        /// The expanded <see cref="Rgba1010102"/> as a <see cref="Vector4"/>.
+        /// </returns>
         public Vector4 ToVector4()
         {
             return new Vector4(
@@ -76,38 +82,50 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
         }
 
         /// <summary>
-        /// Compares an object with the packed vector.
+        /// Returns a value that indicates whether this <see cref="Rgba1010102"/>
+        /// and a specified object are equal.
         /// </summary>
-        /// <param name="obj">The object to compare.</param>
-        /// <returns>True if the object is equal to the packed vector.</returns>
+        /// <param name="obj">The object to compare with this <see cref="Rgba1010102"/>.</param>
+        /// <returns>
+        /// <see langword="true"/> if this <see cref="Rgba1010102"/> and
+        /// <paramref name="obj"/> are equal; otherwise, <see langword="false"/>.
+        /// </returns>
         public override bool Equals(object obj)
         {
             return (obj is Rgba1010102) && Equals((Rgba1010102) obj);
         }
 
         /// <summary>
-        /// Compares another Rgba1010102 packed vector with the packed vector.
+        /// Returns a value tha indicates whether this <see cref="Rgba1010102"/>
+        /// and a specified <see cref="Rgba1010102"/> are equal.
         /// </summary>
-        /// <param name="other">The Rgba1010102 packed vector to compare.</param>
-        /// <returns>True if the packed vectors are equal.</returns>
+        /// <param name="other">The other <see cref="Rgba1010102"/>.</param>
+        /// <returns>
+        /// <see langword="true"/> if the two <see cref="Rgba1010102"/> values
+        /// are equal; otherwise, <see langword="false"/>.
+        /// </returns>
         public bool Equals(Rgba1010102 other)
         {
             return packedValue == other.packedValue;
         }
 
         /// <summary>
-        /// Gets a string representation of the packed vector.
+        /// Returns the string representation of this <see cref="Rgba1010102"/> value.
         /// </summary>
-        /// <returns>A string representation of the packed vector.</returns>
+        /// <returns>
+        /// The string representation of this <see cref="Rgba1010102"/> value.
+        /// </returns>
         public override string ToString()
         {
             return ToVector4().ToString();
         }
 
         /// <summary>
-        /// Gets a hash code of the packed vector.
+        /// Returns the hash code for this <see cref="Rgba1010102"/> value.
         /// </summary>
-        /// <returns>The hash code for the packed vector.</returns>
+        /// <returns>
+        /// The 32-bit signed integer hash code for this <see cref="Rgba1010102"/> value.
+        /// </returns>
         public override int GetHashCode()
         {
             return packedValue.GetHashCode();

--- a/MonoGame.Framework/Graphics/PackedVector/Rgba64.cs
+++ b/MonoGame.Framework/Graphics/PackedVector/Rgba64.cs
@@ -11,9 +11,12 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
 	/// </summary>
 	public struct Rgba64 : IPackedVector<ulong>, IEquatable<Rgba64>, IPackedVector
 	{
-		/// <summary>
-		/// Gets and sets the packed value.
-		/// </summary>
+        /// <summary>
+        /// Gets or Sets the packed representation of this <see cref="Rgba64"/>.
+        /// </summary>
+        /// <value>
+        /// The packed representation of this <see cref="Rgba64"/>.
+        /// </value>
 		public ulong PackedValue
 		{
 			get
@@ -28,33 +31,36 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
 
 		private ulong packedValue;
 
-		/// <summary>
-		/// Creates a new instance of Rgba64.
-		/// </summary>
-		/// <param name="x">The x component</param>
-		/// <param name="y">The y component</param>
-		/// <param name="z">The z component</param>
-		/// <param name="w">The w component</param>
+        /// <summary>
+        /// Creates a new <see cref="Rgba64"/> from the specified component values.
+        /// </summary>
+        /// <param name="x">The initial x-component value.</param>
+        /// <param name="y">The initial y-component value.</param>
+        /// <param name="z">The initial z-component value.</param>
+        /// <param name="w">The initial w-component value.</param>
 		public Rgba64(float x, float y, float z, float w)
 		{
 			packedValue = Pack(x, y, z, w);
 		}
 
-		/// <summary>
-		/// Creates a new instance of Rgba64.
-		/// </summary>
-		/// <param name="vector">
-		/// Vector containing the components for the packed vector.
-		/// </param>
+       /// <summary>
+        /// Creates a new <see cref="Rgba64"/> from the specified <see cref="Vector4"/>.
+        /// </summary>
+        /// <param name="vector">
+        /// The <see cref="Vector4"/> whos components contain the initial values
+        /// for this <see cref="Rgba64"/>.
+        /// </param>
 		public Rgba64(Vector4 vector)
 		{
 			packedValue = Pack(vector.X, vector.Y, vector.Z, vector.W);
 		}
 
-		/// <summary>
-		/// Gets the packed vector in Vector4 format.
-		/// </summary>
-		/// <returns>The packed vector in Vector4 format</returns>
+        /// <summary>
+        /// Expands this <see cref="Rgba64"/> to a <see cref="Vector4"/>
+        /// </summary>
+        /// <returns>
+        /// The expanded <see cref="Rgba64"/> as a <see cref="Vector4"/>.
+        /// </returns>
 		public Vector4 ToVector4()
 		{
 			return new Vector4(
@@ -74,39 +80,51 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
 			packedValue = Pack(vector.X, vector.Y, vector.Z, vector.W);
 		}
 
-		/// <summary>
-		/// Compares an object with the packed vector.
-		/// </summary>
-		/// <param name="obj">The object to compare.</param>
-		/// <returns>True if the object is equal to the packed vector.</returns>
+        /// <summary>
+        /// Returns a value that indicates whether this <see cref="Rgba64"/>
+        /// and a specified object are equal.
+        /// </summary>
+        /// <param name="obj">The object to compare with this <see cref="Rgba64"/>.</param>
+        /// <returns>
+        /// <see langword="true"/> if this <see cref="Rgba64"/> and
+        /// <paramref name="obj"/> are equal; otherwise, <see langword="false"/>.
+        /// </returns>
 		public override bool Equals(object obj)
 		{
 			return (obj is Rgba64) && Equals((Rgba64) obj);
 		}
 
-		/// <summary>
-		/// Compares another Rgba64 packed vector with the packed vector.
-		/// </summary>
-		/// <param name="other">The Rgba64 packed vector to compare.</param>
-		/// <returns>True if the packed vectors are equal.</returns>
+        /// <summary>
+        /// Returns a value tha indicates whether this <see cref="Rgba64"/>
+        /// and a specified <see cref="Rgba64"/> are equal.
+        /// </summary>
+        /// <param name="other">The other <see cref="Rgba64"/>.</param>
+        /// <returns>
+        /// <see langword="true"/> if the two <see cref="Rgba64"/> values
+        /// are equal; otherwise, <see langword="false"/>.
+        /// </returns>
 		public bool Equals(Rgba64 other)
 		{
 			return packedValue == other.packedValue;
 		}
 
-		/// <summary>
-		/// Gets a string representation of the packed vector.
-		/// </summary>
-		/// <returns>A string representation of the packed vector.</returns>
+        /// <summary>
+        /// Returns the string representation of this <see cref="Rgba64"/> value.
+        /// </summary>
+        /// <returns>
+        /// The string representation of this <see cref="Rgba64"/> value.
+        /// </returns>
 		public override string ToString()
 		{
 			return ToVector4().ToString();
 		}
 
-		/// <summary>
-		/// Gets a hash code of the packed vector.
-		/// </summary>
-		/// <returns>The hash code for the packed vector.</returns>
+        /// <summary>
+        /// Returns the hash code for this <see cref="Rgba64"/> value.
+        /// </summary>
+        /// <returns>
+        /// The 32-bit signed integer hash code for this <see cref="Rgba64"/> value.
+        /// </returns>
 		public override int GetHashCode()
 		{
 			return packedValue.GetHashCode();

--- a/MonoGame.Framework/Graphics/PackedVector/Short4.cs
+++ b/MonoGame.Framework/Graphics/PackedVector/Short4.cs
@@ -14,21 +14,24 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
         ulong packedValue;
 
         /// <summary>
-        /// Initializes a new instance of the Short4 class.
+        /// Creates a new <see cref="Short4"/> from the specified <see cref="Vector4"/>.
         /// </summary>
-        /// <param name="vector">A vector containing the initial values for the components of the Short4 structure.</param>
+        /// <param name="vector">
+        /// The <see cref="Vector4"/> whos components contain the initial values
+        /// for this <see cref="Short4"/>.
+        /// </param>
         public Short4(Vector4 vector)
         {
             packedValue = Pack(ref vector);
         }
 
         /// <summary>
-        /// Initializes a new instance of the Short4 class.
+        /// Creates a new <see cref="Short4"/> from the specified component values.
         /// </summary>
-        /// <param name="x">Initial value for the x component.</param>
-        /// <param name="y">Initial value for the y component.</param>
-        /// <param name="z">Initial value for the z component.</param>
-        /// <param name="w">Initial value for the w component.</param>
+        /// <param name="x">The initial x-component value.</param>
+        /// <param name="y">The initial y-component value.</param>
+        /// <param name="z">The initial z-component value.</param>
+        /// <param name="w">The initial w-component value.</param>
         public Short4(float x, float y, float z, float w)
         {
             var vector = new Vector4(x, y, z, w);
@@ -36,31 +39,41 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
         }
 
         /// <summary>
-        /// Compares the current instance of a class to another instance to determine whether they are different.
+        /// Returns a value that indicates whether two <see cref="Short4"/>
+        /// values are not equal.
         /// </summary>
-        /// <param name="a">The object to the left of the equality operator.</param>
-        /// <param name="b">The object to the right of the equality operator.</param>
-        /// <returns>true if the objects are different; false otherwise.</returns>
+        /// <param name="a">The <see cref="Short4"/> on the left of the inequality operator.</param>
+        /// <param name="b">The <see cref="Short4"/> on the right of the inequality operator.</param>
+        /// <returns>
+        /// <see langword="true"/> if <paramref name="a"/> and <paramref name="b"/>
+        /// are different; otherwise, <see langword="false"/>.
+        /// </returns>
         public static bool operator !=(Short4 a, Short4 b)
         {
             return a.PackedValue != b.PackedValue;
         }
 
         /// <summary>
-        /// Compares the current instance of a class to another instance to determine whether they are the same.
+        /// Returns a value that indicates whether two <see cref="Short4"/>
+        /// values are equal.
         /// </summary>
-        /// <param name="a">The object to the left of the equality operator.</param>
-        /// <param name="b">The object to the right of the equality operator.</param>
-        /// <returns>true if the objects are the same; false otherwise.</returns>
+        /// <param name="a">The <see cref="Short4"/> on the left of the equality operator.</param>
+        /// <param name="b">The <see cref="Short4"/> on the right of the equality operator.</param>
+        /// <returns>
+        /// <see langword="true"/> if <paramref name="a"/> and <paramref name="b"/>
+        /// are equal; otherwise, <see langword="false"/>.
+        /// </returns>
         public static bool operator ==(Short4 a, Short4 b)
         {
             return a.PackedValue == b.PackedValue;
         }
 
         /// <summary>
-        /// Directly gets or sets the packed representation of the value.
+        /// Gets or Sets the packed representation of this <see cref="Short4"/>.
         /// </summary>
-        /// <value>The packed representation of the value.</value>
+        /// <value>
+        /// The packed representation of this <see cref="Short4"/>
+        /// </value>
         public ulong PackedValue
         {
             get
@@ -74,10 +87,14 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
         }
 
         /// <summary>
-        /// Returns a value that indicates whether the current instance is equal to a specified object.
+        /// Returns a value that indicates whether this <see cref="Short4"/>
+        /// and a specified object are equal.
         /// </summary>
-        /// <param name="obj">The object with which to make the comparison.</param>
-        /// <returns>true if the current instance is equal to the specified object; false otherwise.</returns>
+        /// <param name="obj">The object to compare with this <see cref="Short4"/>.</param>
+        /// <returns>
+        /// <see langword="true"/> if this <see cref="Short4"/> and
+        /// <paramref name="obj"/> are equal; otherwise, <see langword="false"/>.
+        /// </returns>
         public override bool Equals(object obj)
         {
             if (obj is Short4)
@@ -86,28 +103,36 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
         }
 
         /// <summary>
-        /// Returns a value that indicates whether the current instance is equal to a specified object.
+        /// Returns a value tha indicates whether this <see cref="Short4"/>
+        /// and a specified <see cref="Short4"/> are equal.
         /// </summary>
-        /// <param name="other">The object with which to make the comparison.</param>
-        /// <returns>true if the current instance is equal to the specified object; false otherwise.</returns>
+        /// <param name="other">The other <see cref="Short4"/>.</param>
+        /// <returns>
+        /// <see langword="true"/> if the two <see cref="Short4"/> values
+        /// are equal; otherwise, <see langword="false"/>.
+        /// </returns>
         public bool Equals(Short4 other)
         {
             return this == other;
         }
 
         /// <summary>
-        /// Gets the hash code for the current instance.
+        /// Returns the hash code for this <see cref="Short4"/> value.
         /// </summary>
-        /// <returns>Hash code for the instance.</returns>
+        /// <returns>
+        /// The 32-bit signed integer hash code for this <see cref="Short4"/> value.
+        /// </returns>
         public override int GetHashCode()
         {
             return packedValue.GetHashCode();
         }
 
         /// <summary>
-        /// Returns a string representation of the current instance.
+        /// Returns the string representation of this <see cref="Short4"/> value.
         /// </summary>
-        /// <returns>String that represents the object.</returns>
+        /// <returns>
+        /// The string representation of this <see cref="Short4"/> value.
+        /// </returns>
         public override string ToString()
         {
             return packedValue.ToString("x16");
@@ -143,9 +168,11 @@ namespace Microsoft.Xna.Framework.Graphics.PackedVector
         }
 
         /// <summary>
-        /// Expands the packed representation into a Vector4.
+        /// Expands this <see cref="Short4"/> to a <see cref="Vector4"/>
         /// </summary>
-        /// <returns>The expanded vector.</returns>
+        /// <returns>
+        /// The expanded <see cref="Short4"/> as a <see cref="Vector4"/>.
+        /// </returns>
         public Vector4 ToVector4()
         {
             return new Vector4(


### PR DESCRIPTION
## Description
This PR ensures that all XML documentation across all members in the `Microsoft.Xna.Framework.Graphics.PackedVector` namespace is consistent.

## Reference:
[Feature Request: Resolve Missing XML For Public Type Warnings](https://github.com/MonoGame/MonoGame/issues/8165)